### PR TITLE
Add missing codiceIPA to publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -27,6 +27,8 @@ localisation:
     - it
 it:
   countryExtensionVersion: '0.2'
+    riuso:
+    codiceIPA: unical
 description:
   it:
     genericName: Django admin LDAP manager for Acade


### PR DESCRIPTION
This publiccode.yml does not contain the IPA code, which is mandatory if the repository is owned by a public entity.

Thank you!